### PR TITLE
feat: Pull-ALL / Push-ALL for storageKey + cookie merge key fix

### DIFF
--- a/packages/shared/lib/cloudflare/api.ts
+++ b/packages/shared/lib/cloudflare/api.ts
@@ -102,3 +102,70 @@ export const verifyCloudflareToken = async (accountId: string, token: string) =>
     }
   });
 };
+
+/**
+ * Cloudflare KV supports listing up to ~1000 keys per page via cursor.
+ * https://developers.cloudflare.com/api/operations/storage-kv-namespaces-list-keys
+ */
+export interface KVKeyInfo {
+  name: string;
+  expiration?: number;
+  metadata?: any;
+}
+
+export const listCloudflareKVKeys = async (
+  accountId: string,
+  namespaceId: string,
+  token: string,
+  prefix = '',
+): Promise<string[]> => {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const params = new URLSearchParams();
+    if (prefix) params.set('prefix', prefix);
+    if (cursor) params.set('cursor', cursor);
+    params.set('limit', '1000');
+    const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/keys?${params}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    const json = await res.json();
+    if (!res.ok || !json.success) {
+      return Promise.reject(json);
+    }
+    for (const item of json.result as KVKeyInfo[]) {
+      if (item?.name) keys.push(item.name);
+    }
+    cursor = json.result_info?.cursor || undefined;
+  } while (cursor);
+  return keys;
+};
+
+/**
+ * Read a specific KV key by name (bypassing settingsStorage.storageKey).
+ */
+export const readCloudflareKVByKey = async (
+  accountId: string,
+  namespaceId: string,
+  token: string,
+  storageKey: string,
+): Promise<string> => {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(storageKey)}`;
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (res.status === 404) return '';
+  if (res.status === 200) {
+    return (await res.text()).trim();
+  }
+  return Promise.reject(await res.json());
+};

--- a/packages/shared/lib/cookie/index.ts
+++ b/packages/shared/lib/cookie/index.ts
@@ -1,3 +1,4 @@
 export * from './withCloudflare';
 export * from './withStorage';
+export * from './pullAndMerge';
 

--- a/packages/shared/lib/cookie/pullAndMerge.ts
+++ b/packages/shared/lib/cookie/pullAndMerge.ts
@@ -1,0 +1,242 @@
+import { MessageErrorCode } from '@lib/message';
+import { accountStorage, type AccountInfo } from '@sync-your-cookie/storage/lib/accountStorage';
+import { cookieStorage } from '@sync-your-cookie/storage/lib/cookieStorage';
+import type { ICookiesMap } from '@sync-your-cookie/protobuf';
+
+import { readCloudflareKVByKey } from '../cloudflare/api';
+import { readCookiesMap, mergeAndWriteMultipleDomainCookies } from './withCloudflare';
+import type { ICookie, ILocalStorageItem } from '@sync-your-cookie/protobuf';
+import {
+  base64ToArrayBuffer,
+  decodeCookiesMap,
+  decryptBase64,
+  isBase64Encrypted,
+} from '@sync-your-cookie/protobuf';
+import { settingsStorage } from '@sync-your-cookie/storage/lib/settingsStorage';
+
+const decodeRawContent = async (content: string): Promise<ICookiesMap> => {
+  const settingsInfo = settingsStorage.getSnapshot();
+  const encryptionEnabled = settingsInfo?.encryptionEnabled;
+  const encryptionPassword = settingsInfo?.encryptionPassword;
+
+  let processedContent = content;
+  const protobufEncoding = !content.startsWith('{');
+
+  if (protobufEncoding && isBase64Encrypted(content)) {
+    if (!encryptionEnabled || !encryptionPassword) {
+      throw new Error('Failed to decrypt data. Please check your encryption password.');
+    }
+    processedContent = await decryptBase64(content, encryptionPassword);
+  }
+  if (protobufEncoding) {
+    const compressedBuffer = base64ToArrayBuffer(processedContent);
+    const deMsg = await decodeCookiesMap(compressedBuffer);
+    return JSON.parse(JSON.stringify(deMsg));
+  }
+  return JSON.parse(processedContent);
+};
+
+/**
+ * Pull cookies from the cloud backend (Cloudflare KV / GitHub Gist) for the
+ * currently active `settingsStorage.storageKey`, and merge them into the local
+ * `cookieStorage`.
+ *
+ * Merge strategy: per-domain, cookies are merged by (domain, name); localStorageItems
+ * are merged by (key). On conflict the remote value wins.
+ *
+ * Used after a fresh extension install to restore the user's tracked sites
+ * without having to add each one manually.
+ */
+export const pullAndMergeToLocal = async (
+  accountInfo?: AccountInfo,
+): Promise<{
+  remote: ICookiesMap;
+  counts: {
+    domainsAdded: number;
+    domainsMerged: number;
+    cookiesAdded: number;
+    cookiesOverridden: number;
+    localStorageMerged: number;
+  };
+}> => {
+  const acc = accountInfo || accountStorage.getSnapshot();
+  if (!acc) {
+    return Promise.reject({
+      message: 'Account info is empty',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+  const remote = await readCookiesMap(acc);
+  // `readCookiesMap` returns an ICookiesMap that may still be a protobufjs
+  // Message instance for nested fields; round-trip through JSON to guarantee
+  // a plain object everywhere downstream (Object.entries / spread / storage).
+  const plainRemote: ICookiesMap = JSON.parse(JSON.stringify(remote || {}));
+  const counts = await cookieStorage.mergeFromRemote(plainRemote);
+  return { remote: plainRemote, counts };
+};
+
+/**
+ * Aggregate cookies from MULTIPLE cloud storage keys into local cookieStorage.
+ *
+ * Useful right after reinstall, when:
+ *   - the user had several storageKeys (e.g. one per environment)
+ *   - or wants to bring back sites from a key that wasn't the active one.
+ *
+ * For Cloudflare, lists all keys in the namespace and reads each one whose
+ * value starts with `{` or decodes as a protobuf ICookiesMap.
+ *
+ * For GitHub, the gist is a single file (active storageKey only); this is a
+ * no-op in that case and the caller should use `pullAndMergeToLocal`.
+ */
+export const pullAndMergeAllStorageKeys = async (
+  accountInfo?: AccountInfo,
+): Promise<{
+  perKey: Array<{ storageKey: string; remote: ICookiesMap; counts: { domainsAdded: number; domainsMerged: number; cookiesAdded: number; cookiesOverridden: number; localStorageMerged: number } }>;
+  total: { domainsAdded: number; domainsMerged: number; cookiesAdded: number; cookiesOverridden: number; localStorageMerged: number };
+  keysScanned: number;
+  keysMerged: number;
+}> => {
+  const acc = accountInfo || accountStorage.getSnapshot();
+  if (!acc) {
+    return Promise.reject({
+      message: 'Account info is empty',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+  if (acc.selectedProvider === 'github') {
+    // GitHub Gist = one file per storageKey, but only ONE storageKey is the
+    // currently active one at a time. Best we can do here is pull the active key.
+    const { remote, counts } = await pullAndMergeToLocal(acc);
+    return {
+      perKey: [{ storageKey: settingsStorage.getSnapshot()?.storageKey || '(active)', remote, counts }],
+      total: counts,
+      keysScanned: 1,
+      keysMerged: 1,
+    };
+  }
+  // Cloudflare: list all keys under the namespace, then aggregate.
+  if (!acc.accountId || !acc.namespaceId || !acc.token) {
+    return Promise.reject({
+      message: 'Cloudflare account is not configured',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+  const { listCloudflareKVKeys } = await import('../cloudflare/api');
+  const keys = await listCloudflareKVKeys(acc.accountId, acc.namespaceId, acc.token);
+  const perKey: Array<any> = [];
+  const total = {
+    domainsAdded: 0,
+    domainsMerged: 0,
+    cookiesAdded: 0,
+    cookiesOverridden: 0,
+    localStorageMerged: 0,
+  };
+  let keysMerged = 0;
+  for (const key of keys) {
+    let content = '';
+    try {
+      content = await readCloudflareKVByKey(acc.accountId!, acc.namespaceId!, acc.token!, key);
+    } catch (e) {
+      console.warn('failed to read kv key', key, e);
+      continue;
+    }
+    if (!content) continue;
+    let remote: ICookiesMap;
+    try {
+      remote = await decodeRawContent(content);
+    } catch (e) {
+      console.warn('failed to decode kv key', key, e);
+      continue;
+    }
+    const plainRemote: ICookiesMap = JSON.parse(JSON.stringify(remote || {}));
+    const counts = await cookieStorage.mergeFromRemote(plainRemote);
+    perKey.push({ storageKey: key, remote: plainRemote, counts });
+    total.domainsAdded += counts.domainsAdded;
+    total.domainsMerged += counts.domainsMerged;
+    total.cookiesAdded += counts.cookiesAdded;
+    total.cookiesOverridden += counts.cookiesOverridden;
+    total.localStorageMerged += counts.localStorageMerged;
+    keysMerged += 1;
+  }
+  return { perKey, total, keysScanned: keys.length, keysMerged };
+};
+
+/**
+ * Push the entire local `cookieStorage` to the currently active cloud storage
+ * key (settingsStorage.storageKey) in one shot.
+ *
+ * This is the symmetric counterpart of `pullAndMergeToLocal`. Useful right
+ * before reinstalling or moving to another machine: bundle every tracked
+ * site onto the cloud in a single request.
+ *
+ * Conflict policy: LOCAL WINS (overrides remote per-domain) — because the user
+ * explicitly chose to upload everything and is okay with the active storageKey
+ * becoming the authoritative snapshot of local.
+ */
+export const pushAllToActiveStorageKey = async (accountInfo?: AccountInfo): Promise<{
+  storageKey: string;
+  hosts: number;
+  cookies: number;
+  localStorageItems: number;
+}> => {
+  const acc = accountInfo || accountStorage.getSnapshot();
+  if (!acc) {
+    return Promise.reject({
+      message: 'Account info is empty',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+  const settingsInfo = settingsStorage.getSnapshot();
+  const storageKey = settingsInfo?.storageKey;
+  if (!storageKey) {
+    return Promise.reject({
+      message: 'No active storage key configured',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+  const localSnap = cookieStorage.getSnapshot() || {};
+  const domainCookieMap = localSnap.domainCookieMap || {};
+  const hosts = Object.keys(domainCookieMap);
+  if (hosts.length === 0) {
+    return Promise.reject({
+      message: 'Local cookieStorage is empty, nothing to push',
+      code: MessageErrorCode.AccountCheck,
+    });
+  }
+
+  const payloads: Array<{
+    domain: string;
+    cookies: ICookie[];
+    localStorageItems: ILocalStorageItem[];
+    userAgent?: string;
+  }> = hosts.map(host => {
+    const entry = domainCookieMap[host] || {};
+    return {
+      domain: host,
+      cookies: (entry.cookies || []) as ICookie[],
+      localStorageItems: (entry.localStorageItems || []) as ILocalStorageItem[],
+      userAgent: entry.userAgent || '',
+    };
+  });
+  // Read the existing remote first so we don't drop any data; then write with
+  // our local cookies merged in (local wins on conflict).
+  const oldRemote = await readCookiesMap(acc).catch(() => ({}));
+  const [, merged] = await mergeAndWriteMultipleDomainCookies(
+    acc as any,
+    payloads,
+    oldRemote || {},
+  );
+
+  let cookieCount = 0;
+  let lsCount = 0;
+  for (const p of payloads) {
+    cookieCount += p.cookies.length;
+    lsCount += p.localStorageItems.length;
+  }
+  return {
+    storageKey,
+    hosts: hosts.length,
+    cookies: cookieCount,
+    localStorageItems: lsCount,
+  };
+};

--- a/packages/shared/lib/cookie/withCloudflare.ts
+++ b/packages/shared/lib/cookie/withCloudflare.ts
@@ -91,7 +91,9 @@ export const readCookiesMap = async (accountInfo: AccountInfo): Promise<ICookies
         const compressedBuffer = base64ToArrayBuffer(processedContent);
         const deMsg = await decodeCookiesMap(compressedBuffer);
         console.log('readCookiesMap->deMsg', deMsg);
-        return deMsg;
+        // decodeCookiesMap already returns a plain object via CookiesMap.toObject,
+        // but go through JSON to flatten any leftover class instances.
+        return JSON.parse(JSON.stringify(deMsg));
       } else {
         console.log('readCookiesMap->res', JSON.parse(processedContent));
         return JSON.parse(processedContent);

--- a/packages/storage/lib/cookieStorage.ts
+++ b/packages/storage/lib/cookieStorage.ts
@@ -3,8 +3,50 @@ import { BaseStorage, createStorage, StorageType } from './base';
 
 export interface Cookie extends ICookiesMap {}
 
+type IDomainCookie = NonNullable<ICookiesMap['domainCookieMap']>[string];
+
 const cacheStorageMap = new Map();
 const key = 'cookie-storage-key';
+
+// unique key for a single cookie entry: domain (lowercased) + name
+const cookieKey = (
+  domain: string | null | undefined,
+  name: string | null | undefined,
+  path: string | null | undefined = '/',
+) => {
+  // Use a recognizable, non-empty placeholder for null/undefined so that
+  // multiple cookies without an explicit domain/name don't collapse into one
+  // single bucket (which previously caused data loss during merge).
+  const d = (domain == null ? '__no_domain__' : String(domain)).toLowerCase();
+  const n = name == null ? '__no_name__' : String(name);
+  const p = path || '__no_path__';
+  return `${d}\u0000${n}\u0000${p}`;
+};
+
+// merge remote domain's cookies into local list, "same name+domain => remote wins"
+const mergeCookies = (localCookies: ICookie[] = [], remoteCookies: ICookie[] = []): ICookie[] => {
+  const byKey = new Map<string, ICookie>();
+  // Preserve original semantics (remote wins on conflict), but include `path`
+  // in the key to avoid collapsing cookies that legitimately differ only by path.
+  for (const c of localCookies) byKey.set(cookieKey(c.domain, c.name, c.path), c);
+  for (const c of remoteCookies) byKey.set(cookieKey(c.domain, c.name, c.path), c); // remote wins
+  return Array.from(byKey.values());
+};
+
+// merge remote localStorage items into local, "same key => remote wins"
+const mergeLocalStorageItems = (
+  local: ILocalStorageItem[] = [],
+  remote: ILocalStorageItem[] = [],
+): ILocalStorageItem[] => {
+  const byKey = new Map<string, ILocalStorageItem>();
+  for (const it of local) {
+    if (it.key != null) byKey.set(it.key, it);
+  }
+  for (const it of remote) {
+    if (it.key != null) byKey.set(it.key, it); // remote wins
+  }
+  return Array.from(byKey.values());
+};
 
 const initStorage = (): BaseStorage<Cookie> => {
   if (cacheStorageMap.has(key)) {
@@ -81,5 +123,74 @@ export const cookieStorage = {
       return newVal;
     });
     return newVal;
+  },
+
+  // Merge a remote ICookiesMap into local cookieStorage.
+  // For each remote domain: merge cookies/localStorageItems by (domain,name) / (key),
+  // remote values win on conflict. Remote-only domains are added as-is.
+  // Returns counts { domainsAdded, domainsMerged, cookiesAdded, cookiesOverridden, localStorageMerged }.
+  mergeFromRemote: async (remote: ICookiesMap | undefined | null): Promise<{
+    domainsAdded: number;
+    domainsMerged: number;
+    cookiesAdded: number;
+    cookiesOverridden: number;
+    localStorageMerged: number;
+  }> => {
+    const remoteDomains = remote?.domainCookieMap || {};
+    const counts = {
+      domainsAdded: 0,
+      domainsMerged: 0,
+      cookiesAdded: 0,
+      cookiesOverridden: 0,
+      localStorageMerged: 0,
+    };
+    const localSnap = storage.getSnapshot() || {};
+    const localDomainMap: Record<string, IDomainCookie> = localSnap.domainCookieMap || {};
+
+    await storage.set(currentInfo => {
+      const merged: Record<string, IDomainCookie> = { ...(currentInfo.domainCookieMap || {}) };
+      for (const [domain, remoteEntry] of Object.entries(remoteDomains)) {
+        const remoteCookies: ICookie[] = remoteEntry?.cookies || [];
+        const remoteLS: ILocalStorageItem[] = remoteEntry?.localStorageItems || [];
+        const existing = merged[domain];
+        if (!existing) {
+          merged[domain] = {
+            ...remoteEntry,
+            cookies: [...remoteCookies],
+            localStorageItems: [...remoteLS],
+            createTime: remoteEntry?.createTime || Date.now(),
+            updateTime: Date.now(),
+          };
+          counts.domainsAdded += 1;
+          counts.cookiesAdded += remoteCookies.length;
+          counts.localStorageMerged += remoteLS.length;
+        } else {
+          const localCookies: ICookie[] = existing.cookies || [];
+          const localLS: ILocalStorageItem[] = existing.localStorageItems || [];
+          const localKeys = new Set(localCookies.map((c: ICookie) => cookieKey(c.domain, c.name, c.path)));
+          for (const rc of remoteCookies) {
+            if (localKeys.has(cookieKey(rc.domain, rc.name, rc.path))) {
+              counts.cookiesOverridden += 1;
+            } else {
+              counts.cookiesAdded += 1;
+            }
+          }
+          counts.localStorageMerged += remoteLS.length;
+          merged[domain] = {
+            ...existing,
+            cookies: mergeCookies(localCookies, remoteCookies),
+            localStorageItems: mergeLocalStorageItems(localLS, remoteLS),
+            updateTime: Date.now(),
+          };
+          counts.domainsMerged += 1;
+        }
+      }
+      return {
+        ...currentInfo,
+        domainCookieMap: merged,
+        updateTime: Date.now(),
+      };
+    });
+    return counts;
   },
 };

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -1,4 +1,7 @@
 import {
+  pullAndMergeAllStorageKeys,
+  pullAndMergeToLocal,
+  pushAllToActiveStorageKey,
   useStorageSuspense,
   useTheme,
   verifyCloudflareToken,
@@ -20,7 +23,7 @@ import {
   ThemeDropdown,
   Toaster,
 } from '@sync-your-cookie/ui';
-import { Eye, EyeOff, Info, Loader2, LogOut, SlidersVertical } from 'lucide-react';
+import { Eye, EyeOff, Info, Loader2, LogOut, SlidersVertical, CloudDownload, Layers, CloudUpload } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { SettingsPopover } from './components/SettingsPopover';
@@ -36,6 +39,92 @@ const Options = () => {
   const [loadingSave, setLoadingSave] = useState(false);
 
   const { setTheme } = useTheme();
+
+  const [loadingPull, setLoadingPull] = useState(false);
+  const [loadingPullAll, setLoadingPullAll] = useState(false);
+  const [loadingPushAll, setLoadingPushAll] = useState(false);
+
+  const handlePullFromCloud = async () => {
+    if (!accountInfo?.accountId?.trim() && accountInfo?.selectedProvider !== 'github') {
+      toast.warning('Please configure Cloudflare account first');
+      return;
+    }
+    try {
+      setLoadingPull(true);
+      const { remote, counts } = await pullAndMergeToLocal();
+      const remoteDomains = Object.keys(remote?.domainCookieMap || {});
+      const totalDomains = counts.domainsAdded + counts.domainsMerged;
+      console.log('pull remote domains:', remoteDomains);
+      if (remoteDomains.length === 0) {
+        toast.info('Cloud has no sites under current storageKey');
+      } else if (totalDomains === 0) {
+        toast.info(
+          `Cloud has ${remoteDomains.length} site(s) but local already up-to-date`,
+        );
+      } else {
+        toast.success(
+          `Synced ${totalDomains}/${remoteDomains.length} site(s): +${counts.domainsAdded} added, ${counts.domainsMerged} merged, ${counts.cookiesAdded} new cookies, ${counts.cookiesOverridden} updated`,
+        );
+      }
+    } catch (err: any) {
+      console.log('pull error', err);
+      const msg = err?.message || 'Pull failed';
+      toast.error(msg);
+    } finally {
+      setLoadingPull(false);
+    }
+  };
+
+  const handlePullAllFromCloud = async () => {
+    if (accountInfo?.selectedProvider !== 'cloudflare') {
+      toast.warning('This action only works with Cloudflare KV');
+      return;
+    }
+    if (!accountInfo?.accountId?.trim() || !accountInfo?.namespaceId?.trim() || !accountInfo?.token?.trim()) {
+      toast.warning('Please configure Cloudflare account first');
+      return;
+    }
+    try {
+      setLoadingPullAll(true);
+      const { total, keysScanned, keysMerged, perKey } = await pullAndMergeAllStorageKeys();
+      console.log('pull-all per-key results:', perKey);
+      const uniqueDomains = new Set<string>();
+      for (const item of perKey) {
+        for (const host of Object.keys(item.remote?.domainCookieMap || {})) {
+          uniqueDomains.add(host);
+        }
+      }
+      toast.success(
+        `Scanned ${keysScanned} KV key(s), merged ${keysMerged}: +${total.domainsAdded} added, ${total.domainsMerged} merged across ${uniqueDomains.size} unique host(s)`,
+      );
+    } catch (err: any) {
+      console.log('pull-all error', err);
+      const msg = err?.message || 'Pull all failed';
+      toast.error(msg);
+    } finally {
+      setLoadingPullAll(false);
+    }
+  };
+
+  const handlePushAllToActiveKey = async () => {
+    if (!accountInfo?.accountId?.trim() && accountInfo?.selectedProvider !== 'github') {
+      toast.warning('Please configure Cloudflare account first');
+      return;
+    }
+    try {
+      setLoadingPushAll(true);
+      const result = await pushAllToActiveStorageKey();
+      toast.success(
+        `Pushed ${result.hosts} host(s), ${result.cookies} cookie(s), ${result.localStorageItems} localStorage to KV key "${result.storageKey}"`,
+      );
+    } catch (err: any) {
+      console.log('push-all error', err);
+      const msg = err?.message || 'Push all failed';
+      toast.error(msg);
+    } finally {
+      setLoadingPushAll(false);
+    }
+  };
 
   const handleTokenInput: React.ChangeEventHandler<HTMLInputElement> = evt => {
     setToken(evt.target.value);
@@ -288,6 +377,60 @@ const Options = () => {
               />
             </CardHeader>
             {renderAccount()}
+          </Card>
+        </div>
+        <div className="w-full">
+          <Card className="mx-auto min-w-[400px] max-w-lg mt-4">
+            <CardHeader className="relative">
+              <CardTitle className="text-base">Sync from cloud</CardTitle>
+              <CardDescription className="mt-[-4px]">
+                Pull all sites under the current storageKey and merge into local cookieStorage.
+                Useful right after reinstalling the extension.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                disabled={loadingPull}
+                onClick={handlePullFromCloud}
+                type="button"
+                variant="outline"
+                className="w-full">
+                {loadingPull ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <CloudDownload className="mr-2 h-4 w-4" />
+                )}
+                {loadingPull ? 'Pulling…' : 'Pull & merge from cloud'}
+              </Button>
+              <Button
+                disabled={loadingPullAll || loadingPull}
+                onClick={handlePullAllFromCloud}
+                type="button"
+                variant="ghost"
+                className="w-full mt-2 text-xs"
+                size="sm">
+                {loadingPullAll ? (
+                  <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                ) : (
+                  <Layers className="mr-2 h-3 w-3" />
+                )}
+                {loadingPullAll ? 'Scanning KV…' : 'Pull ALL storage keys (scan namespace)'}
+              </Button>
+              <Button
+                disabled={loadingPushAll || loadingPull || loadingPullAll}
+                onClick={handlePushAllToActiveKey}
+                type="button"
+                variant="ghost"
+                className="w-full mt-2 text-xs"
+                size="sm">
+                {loadingPushAll ? (
+                  <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                ) : (
+                  <CloudUpload className="mr-2 h-3 w-3" />
+                )}
+                {loadingPushAll ? 'Pushing…' : 'Push ALL local → current storage key'}
+              </Button>
+            </CardContent>
           </Card>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Pull ALL storage keys: Scans entire Cloudflare KV namespace, lists all storageKey values, pick one to merge cookies from.
- Push ALL local: Pushes local cookieStorage (all hosts) to current storageKey.
- Cookie merge key fix: cookieKey now includes path and uses placeholders for null domain/name, preventing silent data loss during merge.

## Test plan

- [ ] Pull ALL on Chrome, verify KV key list and cookie counts
- [ ] Push from Chrome, verify KV has all local cookies
- [ ] Pull ALL on Edge, verify count matches
- [ ] Verify cookiesAdded / cookiesOverridden counts match merged result